### PR TITLE
Add curry function 🍛 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A TypeScript monad library with only the things you'll actually use.
 
 > I'm a JS/TS developer interested in using some more functional programming patterns in my code, but all these FP libs don't fit with the way I work!
 
+
 ## Then mondas-lite is what you need!
 
 `monads-lite` is JS/TS library that brings mondic functional programming tools that don't take over your code, and let you expore the benifits functional programming without re-writing your codebase.
@@ -25,6 +26,8 @@ i.e. `type OperationResult = Result.Result<number, 'oh no, I failed'>;`
 A Result can be infered from a Promise if a error type is provided:
 
 ```ts
+import { Result } from 'monads-lite';
+
 const promise = Promise.resolve(123);
 const result: Result<number, CustomErrorType> = 
     inferFrom(promise).resultify<CustomErrorType>();
@@ -33,6 +36,8 @@ const result: Result<number, CustomErrorType> =
 A Result can be matched on if it is an Ok or Err:
 
 ```ts
+import { Result } from 'monads-lite';
+
 // This is a powerful tool for program flow control.
 const value = Result.match(result, [
     (okValue) => handleOk(okValue),
@@ -43,12 +48,16 @@ const value = Result.match(result, [
 Actions can be run inside the Result monadic container so that they will only apply if the Result is of type Ok:
 
 ```ts
+import { Result } from 'monads-lite';
+
 const value = Result.act(result, (okValue) => doNextThing(okValue));
 ```
 
 These actions can be chained:
 
 ```ts
+import { Result } from 'monads-lite';
+
 const value = Result.onResult(result)
     // These actions will only execute if the Result is Ok.
     .act(n => n + 1)
@@ -60,6 +69,8 @@ const value = Result.onResult(result)
 Actions can also be run asynchronously:
 
 ```ts
+import { Result } from 'monads-lite';
+
 const result = await Result.onResult(result)
     .actAsync(async (n) => n + 1)
     .actAsync(async (n) => n * 2)
@@ -69,6 +80,8 @@ const result = await Result.onResult(result)
 Errors thrown anywhere in the act chain will be resolve out as Err:
 
 ```ts
+import { Result } from 'monads-lite';
+
 const result = Result.onValue<number, Error>(2)
     .act((n) => n + 1) // This will run.
     .act(() => {
@@ -109,12 +122,16 @@ i.e. `type Username = Maybe<string>;`
 Actions can be run inside the Maybe monadic container so that they will only apply if the Result is of type Ok:
 
 ```ts
+import { Maybe } from 'monads-lite';
+
 const value = Maybe.act(maybe, (existingValue) => doNextThing(existingValue));
 ```
 
 These actions can be chained:
 
 ```ts
+import { Maybe } from 'monads-lite';
+
 const value = Maybe.onResult(maybe)
     // These actions will only execute if the Result is Ok.
     .act(n => n + 1)
@@ -126,6 +143,8 @@ const value = Maybe.onResult(maybe)
 A Maybe can be matched against cases:
 
 ```ts
+import { Maybe } from 'monads-lite';
+
 // If 2, 3 or 9, repeat the digit 5 times.
 const value = Maybe.match(maybe, [
     n => (n === 2 && (() => 22222)),
@@ -137,6 +156,8 @@ const value = Maybe.match(maybe, [
 When matching a Maybe a default case can also be provided:
 
 ```ts
+import { Maybe } from 'monads-lite';
+
 // If 2, 3 or 9, repeat the digit 5 times,
 // otherwise leave value unchanges.
 const value = Maybe.match(maybe, [

--- a/README.md
+++ b/README.md
@@ -166,3 +166,21 @@ const value = Maybe.match(maybe, [
     n => (n === 9 && (() => 99999)),
 ], n => n);
 ```
+
+## `curry`
+
+The `curry` function can be used to split a multi-argument function into a nested set of single argument functions. This technique is called [currying](https://wikipedia.org/wiki/Currying).
+
+```ts
+import { curry } from 'monads-lite';
+
+const add = (a: number, b: number, c: number) => {
+    return a + b + c;
+};
+
+const curriedAdd = curry(add);
+const addFive = curriedAdd(5);
+const addTwenty = addFive(15);
+
+const thirty: number = addTwenty(10);
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "monads-lite",
-    "version": "1.1.4",
+    "version": "1.1.5-curry.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "monads-lite",
-            "version": "1.1.4",
+            "version": "1.1.5-curry.0",
             "license": "MIT",
             "devDependencies": {
                 "@tsconfig/recommended": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "monads-lite",
-    "version": "1.1.5-curry.0",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "monads-lite",
-            "version": "1.1.5-curry.0",
+            "version": "1.2.0",
             "license": "MIT",
             "devDependencies": {
                 "@tsconfig/recommended": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "monads-lite",
-    "version": "1.1.5-curry.0",
+    "version": "1.2.0",
     "description": "A TypeScript monad library with only the things you'll actually use.",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "monads-lite",
-    "version": "1.1.4",
+    "version": "1.1.5-curry.0",
     "description": "A TypeScript monad library with only the things you'll actually use.",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "prepare": "husky install",
         "lint-staged": "lint-staged",
         "pre-commit": "npm run lint-staged && npm run test",
-        "release": "npm run clean && npm run build && npm publish"
+        "release": "npm run clean && npm run build && npm run test && npm publish"
     },
     "repository": {
         "type": "git",

--- a/src/__tests__/curry.test.ts
+++ b/src/__tests__/curry.test.ts
@@ -1,0 +1,153 @@
+import curry from '../curry';
+
+describe('curry', () => {
+    it('should curry 1 arg function', () => {
+        const double = (a: number) => {
+            return a + a;
+        };
+
+        const curriedDouble = curry(double);
+
+        expect(curriedDouble(3)).toBe(double(3));
+    });
+
+    it('should curry 2 arg function', () => {
+        const add = (a: number, b: number) => {
+            return a + b;
+        };
+
+        const curriedAdd = curry(add);
+
+        expect(curriedAdd(1)(2)).toBe(add(1, 2));
+    });
+
+    it('should curry 3 arg function', () => {
+        const add = (a: number, b: number, c: number) => {
+            return a + b + c;
+        };
+
+        const curriedAdd = curry(add);
+
+        expect(curriedAdd(1)(2)(3)).toBe(add(1, 2, 3));
+    });
+
+    it('should curry 26 arg function', () => {
+        const add = (
+            a: number,
+            b: number,
+            c: number,
+            d: number,
+            e: number,
+            f: number,
+            g: number,
+            h: number,
+            i: number,
+            j: number,
+            k: number,
+            l: number,
+            m: number,
+            n: number,
+            o: number,
+            p: number,
+            q: number,
+            r: number,
+            s: number,
+            t: number,
+            u: number,
+            v: number,
+            w: number,
+            x: number,
+            y: number,
+            z: number
+        ) => {
+            return (
+                a +
+                b +
+                c +
+                d +
+                e +
+                f +
+                g +
+                h +
+                i +
+                j +
+                k +
+                l +
+                m +
+                n +
+                o +
+                p +
+                q +
+                r +
+                x +
+                t +
+                u +
+                v +
+                w +
+                x +
+                y +
+                z
+            );
+        };
+
+        const curriedAdd = curry(add);
+
+        expect(
+            curriedAdd(1)(2)(3)(4)(5)(6)(7)(8)(9)(10)(11)(12)(13)(14)(15)(16)(
+                17
+            )(18)(19)(20)(21)(22)(23)(24)(25)(26)
+        ).toBe(
+            add(
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25,
+                26
+            )
+        );
+    });
+
+    it('should curry 0 arg function', () => {
+        const getNumber = () => {
+            return 123;
+        };
+
+        const curriedGetNumber = curry(getNumber);
+
+        expect(curriedGetNumber()).toBe(getNumber());
+    });
+
+    it('readme example', () => {
+        const add = (a: number, b: number, c: number) => {
+            return a + b + c;
+        };
+
+        const curriedAdd = curry(add);
+        const addFive = curriedAdd(5);
+        const addTwenty = addFive(15);
+
+        const thirty: number = addTwenty(10);
+        expect(thirty).toBe(thirty);
+    });
+});

--- a/src/curry.ts
+++ b/src/curry.ts
@@ -1,0 +1,32 @@
+type FirstArg<T> = T extends () => any
+    ? void
+    : T extends (a: infer Arg, ...rest: any) => any
+    ? Arg
+    : never;
+
+type CurryRest<T> = T extends () => infer ReturnValue
+    ? ReturnValue
+    : T extends (a: infer SingleArg) => any
+    ? SingleArg
+    : T extends (a: any, ...rest: infer RestArgs) => infer ReturnValue
+    ? Curried<(...args: RestArgs) => ReturnValue>
+    : never;
+
+type Curried<T extends (...args: any) => any> = (
+    arg: FirstArg<T>
+) => CurryRest<T>;
+
+const curry = <T extends (...args: any) => any>(fn: T): Curried<T> => {
+    // Handle functions with no args.
+    if (fn.length === 0) return fn;
+
+    const _curry = <T extends (...args: any) => any>(fn: T): CurryRest<T> =>
+        fn.length === 0
+            ? fn.call(null)
+            : (arg: FirstArg<T>) => _curry(fn.bind(null, arg));
+
+    return _curry(fn);
+};
+
+export default curry;
+export { curry };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { Nothing, Either } from './core';
 export * as Result from './result';
 export * as Maybe from './maybe';
-export { Nothing, Either } from './core';
+export * from './curry';


### PR DESCRIPTION
This PR adds a type compliant [curry function](https://wikipedia.org/wiki/Currying) to the monads-lite library.
See readme additions for usage examples.